### PR TITLE
fix nested a tags

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@
                   v-for="(link, i) in links"
                   :key="i"
                   :to="link.to"
+                  custom
                   v-slot="{ navigate, href, isExactActive }"
                 >
                   <a


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19991745/86257430-30808500-bbc2-11ea-8ecf-7c47911fbf01.png)

@posva this change is not triggering hmr on vite 1.0.0-beta.8. actually vite is output `[vite:hmr] src/App.vue updated. (template)`  on console but in browser there is no change until manually reloading. is this problem about `vite` or `this repo` or `vue router next` ?