### PR TITLE
fix: nested anchor tag causing duplicate focus state

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -168,6 +168,7 @@
             v-for="(link, i) in links"
             :key="i"
             :to="link.to"
+            custom
             v-slot="{ navigate, href, isExactActive }"
           >
             <a


### PR DESCRIPTION
This fixes a bug in the mobile menu. When tabbing through the items, there are two focus states.
![Screen Recording](https://user-images.githubusercontent.com/24668338/95755541-d903b200-0ca4-11eb-807e-5a4e2d7ef8df.gif)
This is because the `custom` attribute is missing to the router tag which creates a nested anchor tag.
![image](https://user-images.githubusercontent.com/24668338/95755748-0fd9c800-0ca5-11eb-8c74-9578bbe51857.png)
