### PR TITLE
Remove Duplicate sm padding definitions

### DIFF
--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="px-4 py-6 mt-10  sm:px-0 sm:mt-12 sm:px-6 md:mt-16 lg:mt-20 lg:px-8 xl:mt-28"
+    class="px-4 py-6 mt-10 sm:mt-12 sm:px-6 md:mt-16 lg:mt-20 lg:px-8 xl:mt-28"
   >
     <div class="sm:text-center lg:text-left">
       <h2


### PR DESCRIPTION
The duplicate padding definitions sm:px-0 and sm:px-6 is invalid. I've removed the one that was not rendering.